### PR TITLE
Updated the filename regex matching to be more lenient

### DIFF
--- a/gah
+++ b/gah
@@ -123,10 +123,16 @@ function get_filename_regexp() {
 	local version_regexp_part='([_-]v?[0-9.]+)?'
 	local os_regexp_part=$(get_os_regexp_part)
 	local arch_regexp_part=$(get_arch_regexp_part)
+	local padding_regexp='([._-][a-z0-9]+)*'
 
-	local regexp="${name_regexp_part}${version_regexp_part}"
+	local regexp="${name_regexp_part}"
+	regexp+="${version_regexp_part}"
+	regexp+="${padding_regexp}"
+
 	regexp+="(${os_regexp_part}${arch_regexp_part}|${arch_regexp_part}${os_regexp_part})"
+	regexp+="${padding_regexp}"
 	regexp+="(${EXT_ALL_ARCHIVES})?"
+
 	echo "$regexp"
 }
 

--- a/test/01_regexp_functions.bats
+++ b/test/01_regexp_functions.bats
@@ -153,42 +153,42 @@ teardown() {
 	stub uname \
 		"-s : echo 'Linux'" \
 		"-m : echo 'x86_64'"
-		
+
 	run get_filename_regexp
 
 	assert_success
-	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?'
+	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-][a-z0-9]+)*([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))([._-][a-z0-9]+)*([.](zip|tar.gz|tar.xz|tar.bz2))?'
 }
 
 @test "get_filename_regexp should return proper string for linux/arm64" {
 	stub uname \
 		"-s : echo 'Linux-gnu'" \
 		"-m : echo 'aarch64'"
-		
+
 	run get_filename_regexp
 
 	assert_success
-	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](arm64|aarch64|universal)|[._-](arm64|aarch64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?'
+	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-][a-z0-9]+)*([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](arm64|aarch64|universal)|[._-](arm64|aarch64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))([._-][a-z0-9]+)*([.](zip|tar.gz|tar.xz|tar.bz2))?'
 }
 
 @test "get_filename_regexp should return proper string for macos/amd64" {
 	stub uname \
 		"-s : echo 'Darwin'" \
 		"-m : echo 'amd64'"
-		
+
 	run get_filename_regexp
 
 	assert_success
-	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-](apple[._-])?(darwin|macos|osx)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](apple[._-])?(darwin|macos|osx))(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?'
+	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-][a-z0-9]+)*([._-](apple[._-])?(darwin|macos|osx)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](apple[._-])?(darwin|macos|osx))([._-][a-z0-9]+)*([.](zip|tar.gz|tar.xz|tar.bz2))?'
 }
 
 @test "get_filename_regexp should return proper string for macos/arm64" {
 	stub uname \
 		"-s : echo 'Darwin 19.0.1'" \
 		"-m : echo 'arm64'"
-		
+
 	run get_filename_regexp
 
 	assert_success
-	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-](apple[._-])?(darwin|macos|osx)[._-](arm64|aarch64|universal)|[._-](arm64|aarch64|universal)[._-](apple[._-])?(darwin|macos|osx))(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?'
+	assert_output '([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-][a-z0-9]+)*([._-](apple[._-])?(darwin|macos|osx)[._-](arm64|aarch64|universal)|[._-](arm64|aarch64|universal)[._-](apple[._-])?(darwin|macos|osx))([._-][a-z0-9]+)*([.](zip|tar.gz|tar.xz|tar.bz2))?'
 }


### PR DESCRIPTION
I had some issues trying to donwload a release from the odin-lang/Odin respository. The release names are structured like this: odin-{os}-{arch}-dev-2025-09.zip. The dev-... text before the .zip prevented the filename regex from matching the correct release. I added a padding_regexp after the version and after the os and architecture to be more lenient in the filename matching. I also updated the tests.

Before:
```
❯_ gah install odin-lang/Odin
Fetching release info for: odin-lang/Odin [latest]
[DEBUG] Fetching release information from: https://api.github.com/repos/odin-lang/Odin/releases/latest
[DEBUG] Error status: null
Found release: dev-2025-09
[DEBUG] Checking OS type
[DEBUG] Checking CPU architecture
[DEBUG] Regexp: ^([a-z][a-z0-9_-]+?)([_-]v?[0-9.]+)?([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?$
[DEBUG]   odin-linux-amd64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-linux-arm64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-macos-amd64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-macos-arm64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-windows-amd64-dev-2025-09.zip ... Doesn't match
[DEBUG] No asset matched, trying to find download URL in the release body
```

After:
```
❯_ gah install odin-lang/Odin
Fetching release info for: odin-lang/Odin [latest]
[DEBUG] Fetching release information from: https://api.github.com/repos/odin-lang/Odin/releases/latest
[DEBUG] Error status: null
Found release: dev-2025-09
[DEBUG] Checking OS type
[DEBUG] Checking CPU architecture
[DEBUG] Regexp: ^([a-z][a-z0-9_-]+?)([._-][a-z0-9]+)*([_-]v?[0-9.]+)?([._-](unknown[._-])?(linux|linux-gnu|linux-musl)[._-](amd64|x86_64|x64|universal)|[._-](amd64|x86_64|x64|universal)[._-](unknown[._-])?(linux|linux-gnu|linux-musl))([._-][a-z0-9]+)*(\.zip|\.tar\.gz|\.tar\.xz|\.tar\.bz2)?$
[DEBUG]   odin-linux-amd64-dev-2025-09.zip ... Match!
[DEBUG]   odin-linux-arm64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-macos-amd64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-macos-arm64-dev-2025-09.zip ... Doesn't match
[DEBUG]   odin-windows-amd64-dev-2025-09.zip ... Doesn't match
[DEBUG] Download URL:
https://github.com/odin-lang/Odin/releases/download/dev-2025-09/odin-linux-amd64-dev-2025-09.zip
[DEBUG] Finding digest for URL:
[DEBUG] Found digest in body: sha256:824ef22e419ba5e906838b10f43c431a4e217123b7662b9bf83f6a918decec43
Downloading: odin-linux-amd64-dev-2025-09.zip
```

Let me know if this approach works for you!